### PR TITLE
run db migrations before starting dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "exocortex",
   "version": "0.1.0",
   "scripts": {
+    "predev": "blitz prisma migrate dev",
     "dev": "blitz dev",
     "build": "blitz build",
     "prestart": "blitz prisma migrate deploy",


### PR DESCRIPTION
I'm not entirely sure if it's a good idea, but we can revert it easily if it turns out not to be.
