### PR TITLE
ci: split workflows

### DIFF
--- a/.github/workflows/checks-trusted.yml
+++ b/.github/workflows/checks-trusted.yml
@@ -1,13 +1,17 @@
-name: Checks
+name: Checks (trusted)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_run:
+    workflows: ["Checks (untrusted)"]
+    types:
+      - completed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# Workflows triggered by Dependabot don't have access to GitHub secrets, so the checks that need
+# access to the secrets have to be run in a separate workflow.
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions
 
 jobs:
   check:

--- a/.github/workflows/checks-untrusted.yml
+++ b/.github/workflows/checks-untrusted.yml
@@ -1,0 +1,15 @@
+name: Checks (untrusted)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Workflows triggered by Dependabot don't have access to GitHub secrets, so the checks that need
+# access to the secrets have to be run in a separate workflow.
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions
+
+jobs:
+  nothing:
+    runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows triggered by Dependabot can't access secrets, the recommended
way to resolve this problem is splitting them into an untrusted and
trusted part.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions
